### PR TITLE
Extending runtime dependency on Stripe gem from version 5 through 8.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ version `3.0.0` has [breaking changes](https://github.com/stripe-ruby-mock/strip
 ### Requirements
 
 * ruby >= 2.4.0
-* stripe >5 & <=7.1.0
+* stripe >5 & <=8.5.0
 
 ### Specifications
 

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '> 5', '<= 7.1.0'
+  gem.add_dependency 'stripe', '> 5', '<= 8.5.0'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
Increasing Stripe dependency to `<= 8.5` does not raise any errors in large/complex repository